### PR TITLE
Issues with .rdp files generated from non-CoRD sources

### DIFF
--- a/Source/CRDSession.m
+++ b/Source/CRDSession.m
@@ -1010,9 +1010,16 @@
 			
 	if (fileContents == nil)
 		fileContents = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:NULL];
-	
-	NSArray *fileLines = [fileContents componentsSeparatedByString:@"\r\n"];
-
+    
+    NSArray *fileLines;
+    
+    if ([NSString respondsToSelector:@selector(componentsSeparatedByCharactersInSet:)])
+    {
+        fileLines = [fileContents componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+    } else {
+        fileLines = [fileContents componentsSeparatedByString:@"\r\n"];
+    }
+    
 	if (fileLines == nil)
 	{
 		CRDLog(CRDLogLevelError, @"Couldn't open RDP file '%@'!", path);


### PR DESCRIPTION
I have an application where .rdp files are generated on the fly, and downloaded and opened by the users.   On Windows, this works fine, and on the OSX Version of the MS Remote Desktop Connection app this works as well.   But on CoRD there have been issues opening the file.   It turns out that the problems are because the file uses simply "\n" for new lines.   This change uses the new line character set to fix this issue.
