### PR TITLE
Change CFBundleTypeRole to match quicklookd's requirements

### DIFF
--- a/Library/Quicklook/CoRD Quicklook.qlgenerator/Contents/Info.plist
+++ b/Library/Quicklook/CoRD Quicklook.qlgenerator/Contents/Info.plist
@@ -16,7 +16,7 @@
 			<key>CFBundleTypeName</key>
 			<string>Remote Desktop v1</string>
 			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
+			<string>QLGenerator</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>net.sf.cord.rdp</string>
@@ -36,7 +36,7 @@
 			<key>CFBundleTypeName</key>
 			<string>MS Remote Incident File</string>
 			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
+			<string>QLGenerator</string>
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>net.sf.cord.msrcincident</string>


### PR DESCRIPTION
fixes "[WARNING] Invalid CFBundleTypeRole value in file:///Applications/CoRD.app/Contents/Library/QuickLook/CoRD%20Quicklook.qlgenerator/ (Viewer - should be QLGenerator)"
