### PR TITLE
make window title contain host and port if no label

### DIFF
--- a/Source/AppController.m
+++ b/Source/AppController.m
@@ -2386,7 +2386,7 @@
 		[resizeTarget setFrameUsingName:@"UnifiedWindowFrame"];
 	}
 	else {
-		[gui_unifiedWindow setTitle:[[self viewedServer] label]];
+        [gui_unifiedWindow setTitle:[[self viewedServer] prettyName]];
 		[resizeTarget setFrame:newWindowFrame display:YES];
 	}
 	[NSAnimationContext endGrouping];

--- a/Source/CRDSession.h
+++ b/Source/CRDSession.h
@@ -116,6 +116,7 @@
 // Accessors
 - (NSView *)tabItemView;
 - (NSString *)filename;
+- (NSString *)prettyName;
 - (void)setFilename:(NSString *)path;
 - (void)setIsTemporary:(BOOL)temp;
 - (void)setHostName:(NSString *)newHost;

--- a/Source/CRDSession.m
+++ b/Source/CRDSession.m
@@ -918,6 +918,12 @@
 	return rdpFilename;
 }
 
+- (NSString *)prettyName
+{
+    if (label && ![label isEqualToString:@""]) return label;
+    return [NSString stringWithFormat:@"%@@%@:%ld", username, hostName, (long)port];
+}
+
 - (void)setFilename:(NSString *)path
 {
 	if ([path isEqualToString:rdpFilename])


### PR DESCRIPTION
Hi, we use a external program to drive CoRD.  It invokes CoRD from the command line.  Since we don't always have a label, it's nice to know the username, host and port instead.  This tweak only changes the window title if there isn't a label.

Thanks,
-Brian
