### PR TITLE
Comment out ineffective observation

### DIFF
--- a/Source/CRDSwappedModifiersUtility.m
+++ b/Source/CRDSwappedModifiersUtility.m
@@ -90,7 +90,7 @@ static NSArray *rawDefaultTable;
 			nil] retain];
 		
 	// xxx: doesn't actually inform us of changes
-	[[NSUserDefaults standardUserDefaults] addObserver:[[[CRDSwappedModifiersUtility alloc] init] autorelease] forKeyPath:SwappedModifiersRootKey options:0 context:NULL];	
+	//[[NSUserDefaults standardUserDefaults] addObserver:[[[CRDSwappedModifiersUtility alloc] init] autorelease] forKeyPath:SwappedModifiersRootKey options:0 context:NULL];
 	[CRDSwappedModifiersUtility loadStandardTranslation];
 }
 


### PR DESCRIPTION
Quick-fix #75.

1) `addObserver` doesn't retain observer object.

Thus autoreleasing makes observer release instantly, and dangling pointer causes crash.

https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Protocols/NSKeyValueObserving_Protocol/#//apple_ref/occ/instm/NSObject/addObserver:forKeyPath:options:context:

> Neither the receiver, nor anObserver, are retained.

2) Observation of `com.apple.keyboard.modifiermapping` is ineffective, as the comment goes.

To detect changes, perhaps we can observe `com.apple.keyboard.modifiermapping.${VendorID}-${ProductID}-0` of keyboard.
